### PR TITLE
Bind to all network interfaces

### DIFF
--- a/statsd.rb
+++ b/statsd.rb
@@ -11,7 +11,7 @@ $stdout.sync = true
 c = Term::ANSIColor
 s = UDPSocket.new
 port = ENV.fetch('PORT', 8125)
-s.bind(nil, port)
+s.bind('0.0.0.0', port)
 
 puts "Statsd Dev Server Started on port #{ port }"
 


### PR DESCRIPTION
When I run this container with other docker containers, none of them can talk to this container. This change fixes that problem.